### PR TITLE
New matplotlib

### DIFF
--- a/notebooks/fig_code/figures.py
+++ b/notebooks/fig_code/figures.py
@@ -62,12 +62,15 @@ def visualize_tree(estimator, X, y, boundaries=True,
 
     x_min, x_max = xlim
     y_min, y_max = ylim
-    xx, yy = np.meshgrid(np.linspace(x_min, x_max, 100),
-                         np.linspace(y_min, y_max, 100))
-    Z = estimator.predict(np.c_[xx.ravel(), yy.ravel()])
+    xx, yy = np.meshgrid(np.linspace(x_min, x_max, 101),
+                         np.linspace(y_min, y_max, 101))
+    # mid-cell points
+    xxm = 0.25*(xx[:-1, :-1] + xx[1:, :-1] + xx[1:, :-1] + xx[1:, 1:])
+    yym = 0.25*(yy[:-1, :-1] + yy[1:, :-1] + yy[1:, :-1] + yy[1:, 1:])
+    Z = estimator.predict(np.c_[xxm.ravel(), yym.ravel()])
 
     # Put the result into a color plot
-    Z = Z.reshape(xx.shape)
+    Z = Z.reshape(xxm.shape)
     plt.figure()
     plt.pcolormesh(xx, yy, Z, alpha=0.2, cmap='rainbow')
     plt.clim(y.min(), y.max())

--- a/notebooks/fig_code/figures.py
+++ b/notebooks/fig_code/figures.py
@@ -69,11 +69,11 @@ def visualize_tree(estimator, X, y, boundaries=True,
     # Put the result into a color plot
     Z = Z.reshape(xx.shape)
     plt.figure()
-    plt.pcolormesh(xx, yy, Z, alpha=0.2, cmap='rainbow', shading='auto')
+    plt.pcolormesh(xx, yy, Z, alpha=0.2, cmap='rainbow')
     plt.clim(y.min(), y.max())
 
     # Plot also the training points
-    plt.scatter(X[:, 0], X[:, 1], c=y, s=50, cmap='rainbow', shading='auto')
+    plt.scatter(X[:, 0], X[:, 1], c=y, s=50, cmap='rainbow')
     plt.axis('off')
 
     plt.xlim(x_min, x_max)

--- a/notebooks/fig_code/figures.py
+++ b/notebooks/fig_code/figures.py
@@ -69,11 +69,11 @@ def visualize_tree(estimator, X, y, boundaries=True,
     # Put the result into a color plot
     Z = Z.reshape(xx.shape)
     plt.figure()
-    plt.pcolormesh(xx, yy, Z, alpha=0.2, cmap='rainbow')
+    plt.pcolormesh(xx, yy, Z, alpha=0.2, cmap='rainbow', shading='auto')
     plt.clim(y.min(), y.max())
 
     # Plot also the training points
-    plt.scatter(X[:, 0], X[:, 1], c=y, s=50, cmap='rainbow')
+    plt.scatter(X[:, 0], X[:, 1], c=y, s=50, cmap='rainbow', shading='auto')
     plt.axis('off')
 
     plt.xlim(x_min, x_max)

--- a/notebooks/fig_code/helpers.py
+++ b/notebooks/fig_code/helpers.py
@@ -22,12 +22,15 @@ def plot_iris_knn():
 
     x_min, x_max = X[:, 0].min() - .1, X[:, 0].max() + .1
     y_min, y_max = X[:, 1].min() - .1, X[:, 1].max() + .1
-    xx, yy = np.meshgrid(np.linspace(x_min, x_max, 100),
-                         np.linspace(y_min, y_max, 100))
-    Z = knn.predict(np.c_[xx.ravel(), yy.ravel()])
+    xx, yy = np.meshgrid(np.linspace(x_min, x_max, 101),
+                         np.linspace(y_min, y_max, 101))
+    # mid-cell points
+    xxm = 0.25*(xx[:-1, :-1] + xx[1:, :-1] + xx[1:, :-1] + xx[1:, 1:])
+    yym = 0.25*(yy[:-1, :-1] + yy[1:, :-1] + yy[1:, :-1] + yy[1:, 1:])
+    Z = knn.predict(np.c_[xxm.ravel(), yym.ravel()])
 
     # Put the result into a color plot
-    Z = Z.reshape(xx.shape)
+    Z = Z.reshape(xxm.shape)
     pl.figure()
     pl.pcolormesh(xx, yy, Z, cmap=cmap_light)
 


### PR DESCRIPTION
With more recent version of matplotlib (e.g. 3.4.2), the size of xx, yy must be 1 larger than Z in pcolormesh(xx, yy, Z). Otherwise the following error message will appear:

/Users/pletzera/sklearn_tutorial-nesi/notebooks/fig_code/helpers.py:32: MatplotlibDeprecationWarning: shading='flat' when X and Y have the same dimensions as C is deprecated since 3.3.  Either specify the corners of the quadrilaterals with X and Y, or pass shading='auto', 'nearest' or 'gouraud', or set rcParams['pcolor.shading'].  This will become an error two minor releases later.
  pl.pcolormesh(xx, yy, Z, cmap=cmap_light)

This is because each cell in the grid gets its own colour. So xx and yy have nodal dimensions whereas Z has cell/zonal dimensions. 
