### PR TITLE
Format + ipywidgets + datasets

### DIFF
--- a/notebooks/02.2-Basic-Principles.ipynb
+++ b/notebooks/02.2-Basic-Principles.ipynb
@@ -547,7 +547,7 @@
     "clf = KNeighborsClassifier(n_neighbors=1)\n",
     "clf.fit(X, y)\n",
     "y_pred = clf.predict(X)\n",
-    "print(\"{0} / {1} correct\".format(np.sum(y == y_pred), len(y)))"
+    "print(f\"{np.sum(y == y_pred)} / {len(y)} correct\")"
    ]
   },
   {
@@ -823,7 +823,7 @@
     "clf = LogisticRegression(penalty='l2', max_iter=5000)\n",
     "clf.fit(Xtrain, ytrain)\n",
     "ypred = clf.predict(Xtest)\n",
-    "print(\"{0} / {1} correct\".format(np.sum(ytest == ypred), len(ytest)))"
+    "print(f\"{np.sum(ytest == ypred)} / {len(ytest)} correct\")"
    ]
   },
   {

--- a/notebooks/03.1-Classification-SVMs.ipynb
+++ b/notebooks/03.1-Classification-SVMs.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets.samples_generator import make_blobs\n",
+    "from sklearn.datasets import make_blobs\n",
     "X, y = make_blobs(n_samples=50, centers=2,\n",
     "                  random_state=0, cluster_std=0.60)\n",
     "plt.scatter(X[:, 0], X[:, 1], c=y, s=50, cmap='spring');"
@@ -266,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets.samples_generator import make_circles\n",
+    "from sklearn.datasets import make_circles\n",
     "X, y = make_circles(100, factor=.1, noise=.1)\n",
     "\n",
     "clf = SVC(kernel='linear').fit(X, y)\n",

--- a/notebooks/04.1-Dimensionality-PCA.ipynb
+++ b/notebooks/04.1-Dimensionality-PCA.ipynb
@@ -316,7 +316,7 @@
     "    im = pca.inverse_transform(pca.transform(X[20:21]))\n",
     "\n",
     "    ax.imshow(im.reshape((8, 8)), cmap='binary')\n",
-    "    ax.text(0.95, 0.05, 'n = {0}'.format(i + 1), ha='right',\n",
+    "    ax.text(0.95, 0.05, f'n = {i + 1}', ha='right',\n",
     "            transform=ax.transAxes, color='green')\n",
     "    ax.set_xticks([])\n",
     "    ax.set_yticks([])"
@@ -351,7 +351,7 @@
     "                    for i in range(nside)])\n",
     "    plt.imshow(im)\n",
     "    plt.grid(False)\n",
-    "    plt.title(\"n = {0}, variance = {1:.2f}\".format(n_components, total_var),\n",
+    "    plt.title(f\"n = {n_components}, variance = {total_var:.2f}\",\n",
     "                 size=18)\n",
     "    plt.clim(0, 16)\n",
     "    \n",

--- a/notebooks/04.1-Dimensionality-PCA.ipynb
+++ b/notebooks/04.1-Dimensionality-PCA.ipynb
@@ -24,8 +24,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function, division\n",
-    "\n",
     "%matplotlib inline\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",

--- a/notebooks/04.2-Clustering-KMeans.ipynb
+++ b/notebooks/04.2-Clustering-KMeans.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets.samples_generator import make_blobs\n",
+    "from sklearn.datasets import make_blobs\n",
     "X, y = make_blobs(n_samples=300, centers=4,\n",
     "                  random_state=0, cluster_std=0.60)\n",
     "plt.scatter(X[:, 0], X[:, 1], s=50);"

--- a/notebooks/04.2-Clustering-KMeans.ipynb
+++ b/notebooks/04.2-Clustering-KMeans.ipynb
@@ -387,7 +387,7 @@
     "\n",
     "    plt.figure()\n",
     "    plt.imshow(new_image)\n",
-    "    plt.title('{0} colors'.format(n_colors))"
+    "    plt.title(f'{n_colors} colors'"
    ]
   },
   {

--- a/notebooks/04.2-Clustering-KMeans.ipynb
+++ b/notebooks/04.2-Clustering-KMeans.ipynb
@@ -387,7 +387,7 @@
     "\n",
     "    plt.figure()\n",
     "    plt.imshow(new_image)\n",
-    "    plt.title(f'{n_colors} colors'"
+    "    plt.title(f'{n_colors} colors')"
    ]
   },
   {

--- a/notebooks/05-Validation.ipynb
+++ b/notebooks/05-Validation.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"{0} / {1} correct\".format(np.sum(y == y_pred), len(y)))"
+    "print(f\"{np.sum(y == y_pred)} / {len(y)} correct\")"
    ]
   },
   {
@@ -154,7 +154,7 @@
     "knn = KNeighborsClassifier(n_neighbors=1)\n",
     "knn.fit(X_train, y_train)\n",
     "y_pred = knn.predict(X_test)\n",
-    "print(\"{0} / {1} correct\".format(np.sum(y_test == y_pred), len(y_test)))"
+    "print(f\"{np.sum(y_test == y_pred)} / {len(y_test)} correct\")"
    ]
   },
   {

--- a/notebooks/fig_code/figures.py
+++ b/notebooks/fig_code/figures.py
@@ -1,6 +1,18 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import warnings
+import ipywidgets
+
+
+def interact_adaptor(obj, **kw):
+    # API of ipywidgets changed between versions
+    ipywdgts_version = int(ipywidgets.__version__.split('.')[0])
+    if ipywdgts_version < 7:
+        return ipywidgets.interact(obj, **kw)
+    else:
+        interactive_plot = ipywidgets.interactive(obj, **kw)
+        output = interactive_plot.children[-1]
+        return interactive_plot
 
 
 def plot_venn_diagram():
@@ -117,14 +129,7 @@ def plot_tree_interactive(X, y):
         clf = DecisionTreeClassifier(max_depth=depth, random_state=0)
         visualize_tree(clf, X, y)
 
-    import ipywidgets
-    ipywdgts_version = int(ipywidgets.__version__.split('.')[0])
-    if ipywdgts_version < 7:
-        return ipywidgets.interact(interactive_tree, depth=(1, 5))
-    else:
-        interactive_plot = ipywidgets.interactive(interactive_tree, depth=(1, 5))
-        output = interactive_plot.children[-1]
-        return interactive_plot
+    return interact_adaptor(interactive_tree, depth=(1, 5))
 
 
 def plot_kmeans_interactive(min_clusters=1, max_clusters=6):
@@ -189,8 +194,8 @@ def plot_kmeans_interactive(min_clusters=1, max_clusters=6):
                          ha='right', va='top', size=14)
 
     
-    return interact(_kmeans_step, frame=(0, 50),
-                    n_clusters=[min_clusters, max_clusters])
+    return interact_adaptor(_kmeans_step, frame=(0, 50),
+                            n_clusters=[min_clusters, max_clusters])
 
 
 def plot_image_components(x, coefficients=None, mean=0, components=None,
@@ -241,4 +246,4 @@ def plot_pca_interactive(data, n_components=6):
         plot_image_components(data[i], Xproj[i],
                               pca.mean_, pca.components_)
     
-    interact(show_decomp, i=(0, data.shape[0] - 1));
+    interact_adaptor(show_decomp, i=(0, data.shape[0] - 1));

--- a/notebooks/fig_code/figures.py
+++ b/notebooks/fig_code/figures.py
@@ -130,7 +130,7 @@ def plot_tree_interactive(X, y):
 def plot_kmeans_interactive(min_clusters=1, max_clusters=6):
     from ipywidgets import interact
     from sklearn.metrics.pairwise import euclidean_distances
-    from sklearn.datasets.samples_generator import make_blobs
+    from sklearn.datasets import make_blobs
 
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore')


### PR DESCRIPTION
Hi @jennan 

(1) All the "...".format(...) have been replaced by f"..."
(2) In the latest sklearn version make_blob is in sklearn.datasets and importing from sklearn.datasets.samples_generator is now an error (warning on NeSI jupyter).
(3) There were still places were the ipywidgets API changes had to be fixed although these were lessons we don't intend to present on 28 Sep. These lessons have been fixed

I get warning: 
/opt/nesi/CS400_centos7_bdw/JupyterLab/2.2.4-gimkl-2018b-Python-3.8.1/lib/python3.8/site-packages/matplotlib/axes/_axes.py:6520: MatplotlibDeprecationWarning: 
The 'normed' kwarg was deprecated in Matplotlib 2.1 and will be removed in 3.1. Use 'density' instead.
  cbook.warn_deprecated("2.1", name="'normed'", obj_type="kwarg",
for **lesson 04.3**. This is an error on the latest Python/sklearn/matplotlib.


Tested on NeSI Python 3.8.1 and laptop with Python 3.9.6