### PR TITLE
normed -> density

### DIFF
--- a/notebooks/04.3-Density-GMM.ipynb
+++ b/notebooks/04.3-Density-GMM.ipynb
@@ -60,7 +60,7 @@
     "x = np.concatenate([np.random.normal(0, 2, 2000),\n",
     "                    np.random.normal(5, 5, 2000),\n",
     "                    np.random.normal(3, 0.5, 600)])\n",
-    "plt.hist(x, 80, normed=True)\n",
+    "plt.hist(x, 80, density=True)\n",
     "plt.xlim(-10, 20);"
    ]
   },
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist(x, 80, normed=True, alpha=0.3)\n",
+    "plt.hist(x, 80, density=True, alpha=0.3)\n",
     "plt.plot(xpdf, density, '-r')\n",
     "\n",
     "for i in range(clf.n_components):\n",


### PR DESCRIPTION
The keyword normed is no longer valid when plotting histograms. This caused a warning on NeSI and an error on the latest 
matplotlib                3.4.2            py39hecd8cb5_0  
matplotlib-base           3.4.2            py39h8b3ea08_0  
